### PR TITLE
Feature/pumas microphysics gjf

### DIFF
--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -35,7 +35,7 @@
   kind = kind_phys
   intent = in
 [rh2o]
-  standard_name = gas_constant_of_water_vapor
+  standard_name = gas_constant_water_vapor
   long_name = ideal gas constant for water vapor
   units = J kg-1 K-1
   dimensions = ()
@@ -83,7 +83,7 @@
   kind = kind_phys
   intent = in
 [iulog]
-  standard_name = log_output_unit
+  standard_name = iounit_of_log
   long_name = log output unit
   units = 1
   dimensions = ()

--- a/micro_pumas_ccpp.meta
+++ b/micro_pumas_ccpp.meta
@@ -19,7 +19,7 @@
 ##### Init Arguments
 
 [gravit]
-  standard_name = standard_gravitational_acceleration
+  standard_name = gravitational_acceleration
   long_name = standard gravitational acceleration
   units = m s-2
   dimensions = ()


### PR DESCRIPTION
This is what I was talking about earlier. PUMAS probably has the "correct" standard names, but SCM doesn't yet. Fixing this on the SCM side is more work than reverting to using the wrong SCM standard names in PUMAS. We can fix this later and perhaps maintain a delta in your fork of PUMAS for today? This change is required to work with changes in supermodules.